### PR TITLE
feat!: use GitHub App Client ID instead of App ID for token generation

### DIFF
--- a/.github/workflows/__main-ci.yml
+++ b/.github/workflows/__main-ci.yml
@@ -39,7 +39,7 @@ jobs:
       contents: read
     with:
       update-all: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')) || github.event_name == 'workflow_dispatch' }}
-      github-app-id: ${{ vars.CI_BOT_APP_ID }}
+      github-app-client-id: ${{ vars.CI_BOT_APP_CLIENT_ID }}
     secrets:
       github-app-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
@@ -51,6 +51,6 @@ jobs:
       contents: read
     with:
       artifact-id: ${{ needs.release.outputs.artifact-id }}
-      github-app-id: ${{ vars.CI_BOT_APP_ID }}
+      github-app-client-id: ${{ vars.CI_BOT_APP_CLIENT_ID }}
     secrets:
       github-app-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/__test-action-deployment.yml
+++ b/.github/workflows/__test-action-deployment.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         id: generate-token
         with:
-          app-id: ${{ vars.CI_BOT_APP_ID }}
+          client-id: ${{ vars.CI_BOT_APP_ID }}
           private-key: ${{ secrets.CI_BOT_APP_PRIVATE_KEY }}
 
       - id: delete-deployment

--- a/.github/workflows/clean-deploy-argocd-app-of-apps.yml
+++ b/.github/workflows/clean-deploy-argocd-app-of-apps.yml
@@ -26,9 +26,9 @@ on:
         type: string
         default: '["ubuntu-latest"]'
         required: false
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See https://github.com/actions/create-github-app-token.
         required: false
         type: string
@@ -109,10 +109,10 @@ jobs:
 
       # jscpd:ignore-start
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: ${{ steps.remove-files.outputs.has-changes == 'true' && inputs.github-app-id }}
+        if: ${{ steps.remove-files.outputs.has-changes == 'true' && inputs.github-app-client-id }}
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
       # jscpd:ignore-end
 

--- a/.github/workflows/clean-deploy.yml
+++ b/.github/workflows/clean-deploy.yml
@@ -23,9 +23,9 @@ on:
         type: string
         default: '["ubuntu-latest"]'
         required: false
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See https://github.com/actions/create-github-app-token.
         required: false
         type: string
@@ -140,10 +140,10 @@ jobs:
             }
 
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: ${{ inputs.github-app-id }}
+        if: ${{ inputs.github-app-client-id }}
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
           owner: ${{ steps.prepare-cleaning.outputs.owner }}
 

--- a/.github/workflows/deploy-argocd-app-of-apps.yml
+++ b/.github/workflows/deploy-argocd-app-of-apps.yml
@@ -52,9 +52,9 @@ on:
         required: false
         type: string
         default: "template.yml.tpl"
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See https://github.com/actions/create-github-app-token.
         required: false
         type: string
@@ -222,10 +222,10 @@ jobs:
 
       # jscpd:ignore-start
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: inputs.github-app-id
+        if: inputs.github-app-client-id
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
       # jscpd:ignore-end
 

--- a/.github/workflows/deploy-chart.yml
+++ b/.github/workflows/deploy-chart.yml
@@ -110,9 +110,9 @@ on:
         type: string
         required: false
         default: "[]"
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See https://github.com/actions/create-github-app-token.
         required: false
         type: string
@@ -454,10 +454,10 @@ jobs:
 
       # jscpd:ignore-start
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: inputs.github-app-id
+        if: inputs.github-app-client-id
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
           owner: ${{ steps.prepare-deployment.outputs.owner }}
       # jscpd:ignore-end

--- a/.github/workflows/finish-deploy-argocd-app-of-apps.yml
+++ b/.github/workflows/finish-deploy-argocd-app-of-apps.yml
@@ -30,9 +30,9 @@ on:
         type: string
         default: '["ubuntu-latest"]'
         required: false
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See <https://github.com/actions/create-github-app-token>.
         required: false
         type: string
@@ -145,10 +145,10 @@ jobs:
             core.setFailed(`Status "${status}" is not valid. Valid statuses are: ${JSON.stringify(statesStatuses)}`);
 
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: inputs.github-app-id
+        if: inputs.github-app-client-id
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
           owner: ${{ github.repository_owner }}
 

--- a/.github/workflows/release-actions.yml
+++ b/.github/workflows/release-actions.yml
@@ -30,9 +30,9 @@ on:
         description: "List of extra documentation files to update (if any)."
         required: false
         type: string
-      github-app-id:
+      github-app-client-id:
         description: |
-          GitHub App ID to generate GitHub token in place of github-token.
+          GitHub App Client ID to generate GitHub token in place of github-token.
           See https://github.com/actions/create-github-app-token.
         required: false
         type: string
@@ -313,10 +313,10 @@ jobs:
       # jscpd:ignore-start
 
       - uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
-        if: inputs.github-app-id
+        if: inputs.github-app-client-id
         id: generate-token
         with:
-          app-id: ${{ inputs.github-app-id }}
+          client-id: ${{ inputs.github-app-client-id }}
           private-key: ${{ secrets.github-app-key }}
 
       # jscpd:ignore-end


### PR DESCRIPTION
GitHub now recommends using a GitHub App's Client ID for authentication.